### PR TITLE
fix linux build

### DIFF
--- a/src/lib/openjp2/minpf_plugin_manager.cpp
+++ b/src/lib/openjp2/minpf_plugin_manager.cpp
@@ -87,7 +87,7 @@ const char* minpf_get_dynamic_library_extension(void) {
 #if defined(__APPLE__)
 	return "dylib";
 #elif defined(__linux)
-	return so";
+	return "so";
 #endif
 #endif /* _WIN32 */
 }


### PR DESCRIPTION
[  4%] Building CXX object src/lib/openjp2/CMakeFiles/openjp2.dir/minpf_plugin_manager.cpp.o
/home/ubuntu/grok/grok/src/lib/openjp2/minpf_plugin_manager.cpp:90:11: warning: missing terminating " character
  return so";
           ^