### PR TITLE
Fix error: ‘UINT_MAX’ was not declared in this scope

### DIFF
--- a/src/bin/jp2/opj_decompress.cpp
+++ b/src/bin/jp2/opj_decompress.cpp
@@ -72,6 +72,7 @@
 #include <sys/times.h>
 #include <unistd.h>
 #include <signal.h>
+#include <limits.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>


### PR DESCRIPTION
Adding this line in fixed the error - "‘UINT_MAX’ was not declared in this scope" - which I got when trying to run `make` on this repo from Ubuntu 18.04.