### PR TITLE
Fix for CMake include directories

### DIFF
--- a/cmake/GrokConfig.cmake.in
+++ b/cmake/GrokConfig.cmake.in
@@ -26,7 +26,7 @@ get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 if(EXISTS ${SELF_DIR}/GrokTargets.cmake)
   # This is an install tree
   include(${SELF_DIR}/GrokTargets.cmake)
-  get_filename_component(GROK_INCLUDE_ROOT "${SELF_DIR}/../../@CMAKE_INSTALL_INCLUDEDIR@" ABSOLUTE)
+  get_filename_component(GROK_INCLUDE_ROOT "${SELF_DIR}/../../../@CMAKE_INSTALL_INCLUDEDIR@" ABSOLUTE)
   set(GROK_INCLUDE_DIRS ${GROK_INCLUDE_ROOT})
 
 else()


### PR DESCRIPTION
`GROK_INCLUDE_DIRS` pointed to `<install prefix>/grok/3.0.0/lib/include` instead of `<install prefix>/grok/3.0.0/include`. Adding another `..` in the config fixes this.