### PR TITLE
doc: fix troff warning in libgrokj2k.3 man page

### DIFF
--- a/doc/man/man3/libgrokj2k.3
+++ b/doc/man/man3/libgrokj2k.3
@@ -124,7 +124,7 @@ a library for reading and writing JPEG2000 image files.
 .B CLRSPC_UNKNOWN\fR or \fBCLRSPC_UNSPECIFIED\fR or \fBCLRSPC_SRGB\fR or \fBCLRSPC_GRAY\fR or \fBCLRSPC_SYCC
 .P
 .SH DECOMPRESSION PARAMETERS
-.p
+.P
 typedef struct grk_dparameters 
 .br
 {


### PR DESCRIPTION
I don't know how much outdated the man page is, so I didn't actually packaged it in the end, but I thought that fixing the warning would not hurt.

Fix the following warning in libgrokj2k.3 man page:

```
$ LC_ALL=it_IT.UTF-8 MANROFFSEQ='' MANWIDTH=80 \
  man --warnings -E UTF-8 -l -Tutf8 -Z doc/man/man3/libgrokj2k.3 >/dev/null
troff: <standard input>:127: warning: macro 'p' not defined
```

The issue was pointed out by the 'lintian' tool from Debian:

```
W: libgrokj2k1-dev: manpage-has-errors-from-man usr/share/man/man3/libgrokj2k.3.gz 127: warning: macro 'p' not defined
```