### PR TITLE
Debian packaging fixups 2, add -doc package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,7 +43,6 @@ Description: development files for Grok, a JPEG 2000 image library
  .
  This package contains the development files for Grok
 
-
 Package: grokj2k-tools
 Section: graphics
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,7 @@ Description: JPEG 2000 image compression/decompression library
  progressive decoding by pixel and resolution accuracy.
  It supports lossless and lossy compression and is resilient to image errors.
  .
- This package contains the runtime files for Grok
+ This package contains the runtime files for Grok.
 
 Package: libgrokj2k1-dev
 Section: libdevel
@@ -41,7 +41,7 @@ Description: development files for Grok, a JPEG 2000 image library
  progressive decoding by pixel and resolution accuracy.
  It supports lossless and lossy compression and is resilient to image errors.
  .
- This package contains the development files for Grok
+ This package contains the development files for Grok.
 
 Package: grokj2k-tools
 Section: graphics

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Maintainer: Aaron Boxer <boxerab@gmail.com>
 Homepage: https://github.com/GrokImageCompression/grok
 Build-Depends: cmake (>= 3.16.0),
                debhelper-compat (= 13),
-               doxygen,
                help2man,
                liblcms2-dev,
                libpng-dev,
@@ -12,6 +11,7 @@ Build-Depends: cmake (>= 3.16.0),
                libtiff-dev,
                libturbojpeg0-dev,
                zlib1g-dev
+Build-Depends-Indep: doxygen
 Standards-Version: 4.5.0
 Section: libs
 Vcs-Browser: https://github.com/GrokImageCompression/grok
@@ -35,6 +35,7 @@ Package: libgrokj2k1-dev
 Section: libdevel
 Architecture: any
 Depends: libgrokj2k1 (= ${binary:Version}), ${misc:Depends}
+Recommends: libgrokj2k1-doc (= ${source:Version})
 Description: development files for Grok, a JPEG 2000 image library
  Grok is a library for handling the JPEG 2000 image compression format.
  JPEG 2000 is a wavelet-based image compression standard that permits
@@ -57,3 +58,15 @@ Description: command-line tools for the Grok JPEG 2000 library
   - grk_compress: encode pnm, pgm, pgx, bmp, or ppm file to j2k
                   or jp2 file.
   - grk_dump: dump information contained in a j2k or jp2 file.
+
+Package: libgrokj2k1-doc
+Section: doc
+Architecture: all
+Depends: ${misc:Depends}
+Description: documentation for the Grok JPEG 2000 library
+ Grok is a library for handling the JPEG 2000 image compression format.
+ JPEG 2000 is a wavelet-based image compression standard that permits
+ progressive decoding by pixel and resolution accuracy.
+ It supports lossless and lossy compression and is resilient to image errors.
+ .
+ This package contains the documentation for Grok.

--- a/debian/libgrokj2k1-doc.doc-base
+++ b/debian/libgrokj2k1-doc.doc-base
@@ -1,0 +1,9 @@
+Document: libgrokj2k1
+Title: libgrokj2k1 API Manual
+Author: libgrokj2k1 project
+Abstract: This manual describes the API of Grok, a JPEG 2000 library.
+Section: Programming
+
+Format: HTML
+Index: /usr/share/doc/libgrokj2k1/html/index.html
+Files: /usr/share/doc/libgrokj2k1/html/*.html

--- a/debian/libgrokj2k1-doc.docs
+++ b/debian/libgrokj2k1-doc.docs
@@ -1,0 +1,1 @@
+debian/tmp/usr/share/doc/GROK/html/

--- a/debian/libgrokj2k1.symbols
+++ b/debian/libgrokj2k1.symbols
@@ -1,4 +1,6 @@
-libgrokj2k.so.1 libgrokj2k1 #MINVER#
+libgrokj2k.so.1 libgrokj2k1
+| libgrokj2k1 #MINVER#
+* Build-Depends-Package: libgrokj2k1-dev
  _ZNKSt13__future_base13_State_baseV221_M_is_deferred_futureEv@Base 7.2.0
  _ZNKSt5ctypeIcE8do_widenEc@Base 7.2.0
  _ZNSt13__future_base11_Task_stateISt5_BindIFZN3grk14WaveletForwardINS2_5dwt53EE3runEPNS2_13TileComponentEEUlvE0_vEESaIiEFivEE14_M_run_delayedESt8weak_ptrINS_13_State_baseV2EE@Base 7.2.0


### PR DESCRIPTION
Hi Aaron,

since grok has Doxygen documentation I thought that a `-doc` package would make sense.

Initially I also packaged the `libgrokj2k.3` man page but then I figured it might be outdated so I am leaving that out for now.

Ciao, Antonio