### PR TITLE
Suggestion: Enforce cmake version 3.17 minimum

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # option to set custom grok name space
 #set(GROK_NAMESPACE "FOO")
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.17)
 
 if(NOT GROK_NAMESPACE)
   set(GROK_NAMESPACE "GROK")
@@ -8,6 +8,11 @@ if(NOT GROK_NAMESPACE)
 endif()
 set(GROK_LIBRARY_NAME grokj2k)
 set(GROK_PLUGIN_NAME grokj2k_plugin)
+
+# Always inline
+# smmintrin.h:306:1: error: inlining failed in call to always_inline '__m128i _mm_max_epi32(__m128i, __m128i)': target specific option mismatch
+#  _mm_max_epi32 (__m128i __X, __m128i __Y)
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -msse4.1")
 
 project(${GROK_NAMESPACE} )
 

--- a/tools/travis-ci/run.sh
+++ b/tools/travis-ci/run.sh
@@ -82,6 +82,7 @@ elif [ "${TRAVIS_OS_NAME}" == "linux" ]; then
 	GROK_OS_NAME=linux
 	
 	# We need a newer version of cmake than travis-ci provides
+	# 		So this should also be the minimum version used in the CMakeLists file.
 	wget --no-check-certificate -qO - https://cmake.org/files/v3.17/cmake-3.17.0-Linux-x86_64.tar.gz | tar -xz
 	# copy to a directory that will not changed every version
 	mv cmake-3.17.0-Linux-x86_64 cmake-install


### PR DESCRIPTION
Had a problem installing grok in a docker environment. (In my humble opinion) When the oldest version tested in travis is 3.17, then it should be the minimum required version for this software also. Just a suggestion. 