### PR TITLE
Fix region

### DIFF
--- a/src/lib/jp2/codestream/CodeStreamDecompress.cpp
+++ b/src/lib/jp2/codestream/CodeStreamDecompress.cpp
@@ -253,7 +253,8 @@ bool CodeStreamDecompress::setDecompressRegion(grk_rect_single region)
 		return false;
 	}
 
-	if(region != grk_rect_single(0, 0, 0, 0))
+	if(((uint32_t)region.x0 + image->x0) != 0 && ((uint32_t)region.y0 + image->y0) != 0 &&
+       ((uint32_t)region.x1 + image->x1) != 0 && ((uint32_t)region.y1 + image->y1) != 0)
 	{
 		grk_rect16 tilesToDecompress;
 		/* Check if the region provided by the user is correct */


### PR DESCRIPTION
```
CodeStreamDecompress.cpp:253:19: error: no match for 'operator!=' (operand types are 'grk::grk_rect_single' {aka 'grk::grk_rect<float>'} and 'grk::grk_rect_single' {aka 'grk::grk_rect<float>'})
  253 |         if(region != grk_rect_single(0, 0, 0, 0))
      |            ~~~~~~ ^~ ~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |            |         |
      |            |         grk_rect<[...]>
      |            grk_rect<[...]>
In file included from c:\msys1130\x86_64-w64-mingw32\include\winnt.h:635,
                 from c:\msys1130\x86_64-w64-mingw32\include\minwindef.h:163,
                 from c:\msys1130\x86_64-w64-mingw32\include\synchapi.h:10,
                 from c:\msys1130\include\c++\11.3.0\bits\std_thread.h:65,
                 from c:\msys1130\include\c++\11.3.0\thread:43,
                 from c:\msys1130\x86_64-w64-mingw32\include\taskflow\utility\object_pool.hpp:15,
                 from c:\msys1130\x86_64-w64-mingw32\include\taskflow\core/graph.hpp:4,
                 from c:\msys1130\x86_64-w64-mingw32\include\taskflow\core/task.hpp:3,
                 from c:\msys1130\x86_64-w64-mingw32\include\taskflow\core/observer.hpp:3,
                 from c:\msys1130\x86_64-w64-mingw32\include\taskflow\core/executor.hpp:3,
                 from c:\msys1130\x86_64-w64-mingw32\include\taskflow\taskflow.hpp:3,
                 from ThreadPool.hpp:27,
                 from grk_includes.h:90,
                 from CodeStreamDecompress.cpp:22:
c:\msys1130\x86_64-w64-mingw32\include\guiddef.h:181:15: note: candidate: 'bool operator!=(const GUID&, const GUID&)'
  181 | __inline bool operator!= (REFGUID guidOne, REFGUID guidOther) { return ! (guidOne == guidOther); }
      |               ^~~~~~~~
c:\msys1130\x86_64-w64-mingw32\include\guiddef.h:181:35: note:   no known conversion for argument 1 from 'grk::grk_rect_single' {aka 'grk::grk_rect<float>'} to 'const GUID&'
  181 | __inline bool operator!= (REFGUID guidOne, REFGUID guidOther) { return ! (guidOne == guidOther); }
      |                                   ^
```