### PR TITLE
exif.cpp: include iostream before perl headers

### DIFF
--- a/src/lib/codec/common/exif.cpp
+++ b/src/lib/codec/common/exif.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "grk_apps_config.h"
+#include <iostream>
 #ifdef GROK_HAVE_EXIFTOOL
 #ifndef _MSC_VER
 #pragma GCC diagnostic push
@@ -36,7 +37,6 @@
 #endif
 #include "exif.h"
 #include <stdexcept>
-#include <iostream>
 
 namespace grk
 {


### PR DESCRIPTION
Error seen while building v10.0.4 on macOS for Homebrew update (https://github.com/Homebrew/homebrew-core/pull/112269) due to macros in perl headers having conflicting names with C++ headers.
```
[ 92%] Building CXX object src/lib/codec/CMakeFiles/grokj2kcodec.dir/common/spdlog/fmt.cpp.o
  cd /tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/build/src/lib/codec && /opt/homebrew/Library/Homebrew/shims/mac/super/llvm_clang++ -DSPDLOG_COMPILED_LIB -Dgrokj2kcodec_EXPORTS -I/opt/homebrew/opt/little-cms2/include -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/thirdparty/libpng -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/thirdparty/libtiff -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/build/thirdparty/libtiff -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/build/src/bin -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/build/src/lib/core -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/src/lib/core -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/src/include -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/build/src/lib/codec -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/src/lib/codec/image_format -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/src/lib/codec/common -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/src/lib/codec/jp2 -I/Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/System/Library/Perl/5.30/darwin-thread-multi-2level/CORE -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/build/thirdparty/libz -I/tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/thirdparty/libz -DCMS_NO_REGISTER_KEYWORD=1 -fvisibility=hidden -O3 -DNDEBUG -arch arm64 -isysroot /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk -fPIC -Wall -Wextra -Wconversion -Wsign-conversion -Wunused-parameter -std=gnu++20 -MD -MT src/lib/codec/CMakeFiles/grokj2kcodec.dir/common/spdlog/fmt.cpp.o -MF CMakeFiles/grokj2kcodec.dir/common/spdlog/fmt.cpp.o.d -o CMakeFiles/grokj2kcodec.dir/common/spdlog/fmt.cpp.o -c /tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/src/lib/codec/common/spdlog/fmt.cpp
  In file included from /tmp/grokj2k-20221003-19454-19fj1n7/grok-10.0.4/src/lib/codec/common/exif.cpp:39:
  In file included from /opt/homebrew/opt/llvm/bin/../include/c++/v1/iostream:42:
  In file included from /opt/homebrew/opt/llvm/bin/../include/c++/v1/istream:165:
  In file included from /opt/homebrew/opt/llvm/bin/../include/c++/v1/ostream:170:
  /opt/homebrew/opt/llvm/bin/../include/c++/v1/locale:3500:35: error: too few arguments provided to function-like macro invocation
          return do_open(__nm, __loc);
                                    ^
  /Library/Developer/CommandLineTools/SDKs/MacOSX12.sdk/System/Library/Perl/5.30/darwin-thread-multi-2level/CORE/perl.h:6924:9: note: macro 'do_open' defined here
  #define do_open(g, n, l, a, rm, rp, sf) \
          ^
```

---

The issue is mentioned by Swig https://www.swig.org/Doc4.0/Perl5.html#Perl5_nn9

> Finally, recent versions of Perl (5.8.0) have namespace conflict problems. Perl defines a bunch of short macros to make the Perl API function names shorter. For example, in /usr/lib/perl/5.8.0/CORE/embed.h there is a line:
> ```
> #define do_open Perl_do_open
> ```
> The problem is, in the <iostream> header from GNU libstdc++v3 there is a private function named do_open. If <iostream> is included after the perl headers, then the Perl macro causes the iostream do_open to be renamed, which causes compile errors.

Though on macOS this would be for XCode/LLVM libc++.

---

Just including `iostream` before any Perl headers should avoid macros being exposed.
