### PR TITLE
cmake/ucm.cmake: workaround for cmake 4

### DIFF
--- a/cmake/ucm.cmake
+++ b/cmake/ucm.cmake
@@ -10,7 +10,7 @@
 # The documentation can be found at the library's page:
 # https://github.com/onqtam/ucm
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 include(CMakeParseArguments)
 


### PR DESCRIPTION
cmake 4 build failed and so update `cmake_minimum_required` for `ucm`.