### PR TITLE
point_transform: restore grk_includes in mct

### DIFF
--- a/src/lib/core/point_transform/mct.cpp
+++ b/src/lib/core/point_transform/mct.cpp
@@ -21,6 +21,7 @@
 #include "CodeStreamLimits.h"
 #include "TileWindow.h"
 #include "Quantizer.h"
+#include "grk_includes.h"
 #include "Logger.h"
 #include "buffer.h"
 #include "GrkObjectWrapper.h"


### PR DESCRIPTION
`mct.cpp` stopped including `grk_includes.h`, so the existing arm64 `HWY_DISABLED_TARGETS` settings no longer apply before the Highway headers are pulled in.

Restore that include to avoid the Linux arm64 SVE/SVE2 `mct.cpp` build failure seen in Homebrew:
- https://github.com/Homebrew/homebrew-core/pull/272285
- https://github.com/Homebrew/homebrew-core/actions/runs/23089647339/job/67072158813