### PR TITLE
Security fixes from the Anvil audit (GHSA-57w8-h6pj-xx45)

### DIFF
--- a/src/lib/codec/formats/BMPFormat.h
+++ b/src/lib/codec/formats/BMPFormat.h
@@ -571,12 +571,9 @@ template<typename T>
 bool BMPFormat<T>::readInfoHeader(const GRK_BITMAPFILEHEADER* fileHeader,
                                   GRK_BITMAPINFOHEADER* infoHeader)
 {
-  const size_t len_initial = infoHeader->biSize - sizeof(uint32_t);
-  uint8_t temp[sizeof(GRK_BITMAPINFOHEADER)];
-  auto temp_ptr = (uint32_t*)temp;
-  if(!read(temp, len_initial))
-    return false;
-
+  // Validate biSize against the legal header-size set BEFORE using it to size
+  // the read: an unvalidated biSize either underflows len_initial (biSize < 4)
+  // or overruns the fixed temp buffer (biSize > sizeof temp), smashing the stack.
   switch(infoHeader->biSize)
   {
     case BITMAPCOREHEADER_LENGTH:
@@ -590,6 +587,13 @@ bool BMPFormat<T>::readInfoHeader(const GRK_BITMAPFILEHEADER* fileHeader,
       spdlog::error("unknown BMP header size {}", infoHeader->biSize);
       return false;
   }
+  const size_t len_initial = infoHeader->biSize - sizeof(uint32_t);
+  uint8_t temp[sizeof(GRK_BITMAPINFOHEADER)];
+  auto temp_ptr = (uint32_t*)temp;
+  if(len_initial > sizeof(temp))
+    return false;
+  if(!read(temp, len_initial))
+    return false;
   bool is_os2 = infoHeader->biSize == BITMAPCOREHEADER_LENGTH;
   if(is_os2)
   { // OS2

--- a/src/lib/codec/formats/BMPFormat.h
+++ b/src/lib/codec/formats/BMPFormat.h
@@ -687,6 +687,7 @@ bool BMPFormat<T>::readRle8Data(uint8_t* pData, uint32_t stride, uint32_t width,
   uint8_t* pix = nullptr;
   const uint8_t* beyond = nullptr;
   const uint8_t* pixels_ptr = nullptr;
+  const uint8_t* pixels_end = nullptr;
   bool rc = false;
   auto pixels = new uint8_t[infoHeader_.biSizeImage];
   if(!read(pixels, infoHeader_.biSizeImage))
@@ -694,15 +695,21 @@ bool BMPFormat<T>::readRle8Data(uint8_t* pData, uint32_t stride, uint32_t width,
     goto cleanup;
   }
   pixels_ptr = pixels;
+  pixels_end = pixels + infoHeader_.biSizeImage;
   beyond = pData + (size_t)stride * height;
   pix = pData;
 
   while(y < height)
   {
+    // every read below must stay within the biSizeImage-sized input buffer
+    if(pixels_ptr >= pixels_end)
+      goto cleanup;
     int c = *pixels_ptr++;
     if(c)
     {
       int j;
+      if(pixels_ptr >= pixels_end)
+        goto cleanup;
       uint8_t c1 = *pixels_ptr++;
       for(j = 0; (j < c) && (x < width) && ((size_t)pix < (size_t)beyond); j++, x++, pix++)
       {
@@ -712,6 +719,8 @@ bool BMPFormat<T>::readRle8Data(uint8_t* pData, uint32_t stride, uint32_t width,
     }
     else
     {
+      if(pixels_ptr >= pixels_end)
+        goto cleanup;
       c = *pixels_ptr++;
       if(c == 0x00)
       { /* EOL */
@@ -725,6 +734,8 @@ bool BMPFormat<T>::readRle8Data(uint8_t* pData, uint32_t stride, uint32_t width,
       }
       else if(c == 0x02)
       { /* MOVE by dxdy */
+        if(pixels_ptr + 2 > pixels_end)
+          goto cleanup;
         c = *pixels_ptr++;
         x += (uint32_t)c;
         c = *pixels_ptr++;
@@ -736,6 +747,8 @@ bool BMPFormat<T>::readRle8Data(uint8_t* pData, uint32_t stride, uint32_t width,
         int j;
         for(j = 0; (j < c) && (x < width) && ((size_t)pix < (size_t)beyond); j++, x++, pix++)
         {
+          if(pixels_ptr >= pixels_end)
+            goto cleanup;
           uint8_t c1 = *pixels_ptr++;
           *pix = c1;
           written++;
@@ -764,20 +777,27 @@ bool BMPFormat<T>::readRle4Data(uint8_t* pData, uint32_t stride, uint32_t width,
   uint32_t x = 0, y = 0, written = 0;
   uint8_t* pix = nullptr;
   const uint8_t* pixels_ptr = nullptr;
+  const uint8_t* pixels_end = nullptr;
   const uint8_t* beyond = nullptr;
   bool rc = false;
   auto pixels = new uint8_t[infoHeader_.biSizeImage];
   if(!read(pixels, infoHeader_.biSizeImage))
     goto cleanup;
   pixels_ptr = pixels;
+  pixels_end = pixels + infoHeader_.biSizeImage;
   beyond = pData + (size_t)stride * height;
   pix = pData;
   while(y < height)
   {
+    // every read below must stay within the biSizeImage-sized input buffer
+    if(pixels_ptr >= pixels_end)
+      goto cleanup;
     int c = *pixels_ptr++;
     if(c)
     { /* encoded mode */
       int j;
+      if(pixels_ptr >= pixels_end)
+        goto cleanup;
       uint8_t c1 = *pixels_ptr++;
 
       for(j = 0; (j < c) && (x < width) && ((size_t)pix < (size_t)beyond); j++, x++, pix++)
@@ -788,6 +808,8 @@ bool BMPFormat<T>::readRle4Data(uint8_t* pData, uint32_t stride, uint32_t width,
     }
     else
     { /* absolute mode */
+      if(pixels_ptr >= pixels_end)
+        goto cleanup;
       c = *pixels_ptr++;
       if(c == 0x00)
       { /* EOL */
@@ -801,6 +823,8 @@ bool BMPFormat<T>::readRle4Data(uint8_t* pData, uint32_t stride, uint32_t width,
       }
       else if(c == 0x02)
       { /* MOVE by dxdy */
+        if(pixels_ptr + 2 > pixels_end)
+          goto cleanup;
         c = *pixels_ptr++;
         x += (uint32_t)c;
 
@@ -816,7 +840,11 @@ bool BMPFormat<T>::readRle4Data(uint8_t* pData, uint32_t stride, uint32_t width,
         for(j = 0; (j < c) && (x < width) && ((size_t)pix < (size_t)beyond); j++, x++, pix++)
         {
           if((j & 1) == 0)
+          {
+            if(pixels_ptr >= pixels_end)
+              goto cleanup;
             c1 = *pixels_ptr++;
+          }
           *pix = (uint8_t)((j & 1) ? (c1 & 0x0fU) : ((uint8_t)(c1 >> 4) & 0x0fU));
           written++;
         }

--- a/src/lib/codec/formats/JPEGFormat.h
+++ b/src/lib/codec/formats/JPEGFormat.h
@@ -222,6 +222,14 @@ grk_image* JPEGFormat<T>::jpegtoimage(const char* filename, grk_cparameters* par
     success = false;
     goto cleanup;
   }
+  // cmptparm[]/planes[] are sized for at most 3 components; a 4-component
+  // (Adobe CMYK/YCCK) JPEG would otherwise overflow those stack arrays.
+  if(cinfo.output_components > 3)
+  {
+    spdlog::error("jpegtoimage: Unsupported number of components {}", cinfo.output_components);
+    success = false;
+    goto cleanup;
+  }
 
   decompress_num_comps = (uint16_t)cinfo.output_components;
   w = cinfo.image_width;

--- a/src/lib/codec/formats/TIFFFormat.h
+++ b/src/lib/codec/formats/TIFFFormat.h
@@ -2273,6 +2273,17 @@ grk_image* TIFFFormat<T>::readImage(const std::string& filename, grk_cparameters
       image->meta->exif_len = exif_size;
     }
   }
+  // For chunky (interleaved) data the per-row scratch buffer is sized from
+  // tiSpp, but the de-interleavers read width*numcomps samples. If the
+  // photometric/extrasamples-derived numcomps exceeds the SamplesPerPixel tag,
+  // the readers over-read the row buffer, so require them to agree.
+  if(tiPC == PLANARCONFIG_CONTIG && numcomps != tiSpp)
+  {
+    spdlog::error("TIFFFormat<T>::readImage: component count {} does not match "
+                  "SamplesPerPixel {} for contiguous (chunky) data",
+                  numcomps, tiSpp);
+    goto cleanup;
+  }
   // 9. read pixel data
   if(needSignedPixelReader)
   {

--- a/src/lib/core/codestream/decompress/CodeStreamDecompress.cpp
+++ b/src/lib/core/codestream/decompress/CodeStreamDecompress.cpp
@@ -2451,9 +2451,33 @@ bool CodeStreamDecompress::activateScratch(bool singleTile, GrkImage* scratch)
       auto comp = scratch->comps + i;
       comp->y0 = ceildivpow2<uint32_t>(ceildiv<uint32_t>(unreducedTileY0, comp->dy), reduce);
       uint32_t compY1 = ceildivpow2<uint32_t>(ceildiv<uint32_t>(unreducedTileY1, comp->dy), reduce);
+      // The drain loop advances comp->h to each later tile-row height without
+      // reallocating; a non-tile-aligned YTOsiz can make an interior row taller
+      // than the first, so size the buffer for the TALLEST reduced row.
+      uint32_t maxH = compY1 - comp->y0;
+      for(uint16_t ty = (uint16_t)(slatedRect.y0 + 1); ty < slatedRect.y1; ty++)
+      {
+        uint32_t uy0 = cp_.ty0_ + (uint32_t)ty * cp_.t_height_;
+        uint32_t uy1 = std::min(uy0 + cp_.t_height_, (uint32_t)scratch->y1);
+        if(uy0 >= uy1)
+          continue;
+        uint32_t ry0 = ceildivpow2<uint32_t>(ceildiv<uint32_t>(uy0, comp->dy), reduce);
+        uint32_t ry1 = ceildivpow2<uint32_t>(ceildiv<uint32_t>(uy1, comp->dy), reduce);
+        maxH = std::max(maxH, ry1 - ry0);
+      }
+      comp->h = maxH;
+    }
+    if(!scratch->allocCompositeData())
+      return false;
+    // report the first tile-row height for the initial decode; the buffer stays
+    // sized for maxH so later (taller) rows still fit.
+    for(uint16_t i = 0; i < scratch->numcomps; i++)
+    {
+      auto comp = scratch->comps + i;
+      uint32_t compY1 = ceildivpow2<uint32_t>(ceildiv<uint32_t>(unreducedTileY1, comp->dy), reduce);
       comp->h = compY1 - comp->y0;
     }
-    return scratch->allocCompositeData();
+    return true;
   }
 
   return cp_.codingParams_.dec_.skipAllocateComposite_ || scratch->allocCompositeData();

--- a/src/lib/core/fileformat/FileFormatJP2Family.cpp
+++ b/src/lib/core/fileformat/FileFormatJP2Family.cpp
@@ -1279,10 +1279,20 @@ bool FileFormatJP2Family::read_asoc(uint8_t* header_data, uint32_t header_data_s
 
   return true;
 }
+// maximum JP2/JPX asoc superbox nesting depth (stack-exhaustion guard)
+static constexpr uint32_t maxAsocDepth = 64;
 uint32_t FileFormatJP2Family::read_asoc(AsocBox* parent, uint8_t** header_data,
-                                        uint32_t* header_data_size, uint32_t asocSize)
+                                        uint32_t* header_data_size, uint32_t asocSize,
+                                        uint32_t depth)
 {
   assert(*header_data);
+  // cap nesting: each level consumes only the 8-byte child header, so a few-MB
+  // payload of nested asoc boxes would otherwise exhaust the stack.
+  if(depth > maxAsocDepth)
+  {
+    grklog.error("ASOC box nesting exceeds maximum depth %u", maxAsocDepth);
+    throw BadAsocException();
+  }
   if(asocSize < 8)
   {
     grklog.error("ASOC box must be at least 8 bytes in size");
@@ -1329,7 +1339,7 @@ uint32_t FileFormatJP2Family::read_asoc(AsocBox* parent, uint8_t** header_data,
         asocBytesUsed += childSize;
         break;
       case JP2_ASOC:
-        asocBytesUsed += read_asoc(childAsoc, header_data, header_data_size, childSize);
+        asocBytesUsed += read_asoc(childAsoc, header_data, header_data_size, childSize, depth + 1);
         break;
       case JP2_XML:
         childAsoc->alloc(childSize);

--- a/src/lib/core/fileformat/FileFormatJP2Family.h
+++ b/src/lib/core/fileformat/FileFormatJP2Family.h
@@ -164,7 +164,7 @@ protected:
   const FindHandlerInfo img_find_handler(uint32_t id);
 
   uint32_t read_asoc(AsocBox* parent, uint8_t** header_data, uint32_t* header_data_size,
-                     uint32_t asocSize);
+                     uint32_t asocSize, uint32_t depth = 0);
   bool read_asoc(uint8_t* header_data, uint32_t header_data_size);
   void serializeAsoc(AsocBox* asoc, grk_asoc* serial_asocs, uint32_t* num_asocs, uint32_t level);
   /***

--- a/src/lib/core/fileformat/decompress/FileFormatMJ2Decompress.cpp
+++ b/src/lib/core/fileformat/decompress/FileFormatMJ2Decompress.cpp
@@ -340,6 +340,10 @@ bool FileFormatMJ2Decompress::read_url(uint8_t* headerData, uint32_t headerSize)
     grklog.error("MJ2: url box outside of a track");
     return false;
   }
+  // version+flags is a 4-byte fullbox header; guard the subtraction so a short
+  // box does not underflow headerSize into a huge value and over-read below.
+  if(headerSize < 4)
+    return false;
   uint8_t version;
   uint32_t flag;
   read_version_and_flag(&headerData, version, flag);
@@ -368,6 +372,10 @@ bool FileFormatMJ2Decompress::read_urn(uint8_t* headerData, uint32_t headerSize)
     grklog.error("MJ2: urn box outside of a track");
     return false;
   }
+  // version+flags is a 4-byte fullbox header; guard the subtraction so a short
+  // box does not underflow headerSize into a huge value and over-read below.
+  if(headerSize < 4)
+    return false;
   uint8_t version;
   uint32_t flag;
   read_version_and_flag(&headerData, version, flag);

--- a/src/lib/core/fileformat/decompress/FileFormatMJ2Decompress.cpp
+++ b/src/lib/core/fileformat/decompress/FileFormatMJ2Decompress.cpp
@@ -334,6 +334,12 @@ bool FileFormatMJ2Decompress::read_vmhd(uint8_t* headerData, uint32_t headerSize
 
 bool FileFormatMJ2Decompress::read_url(uint8_t* headerData, uint32_t headerSize)
 {
+  // a dref/url box can appear with no preceding tkhd, leaving current_track_ null
+  if(!current_track_)
+  {
+    grklog.error("MJ2: url box outside of a track");
+    return false;
+  }
   uint8_t version;
   uint32_t flag;
   read_version_and_flag(&headerData, version, flag);
@@ -356,6 +362,12 @@ bool FileFormatMJ2Decompress::read_url(uint8_t* headerData, uint32_t headerSize)
 
 bool FileFormatMJ2Decompress::read_urn(uint8_t* headerData, uint32_t headerSize)
 {
+  // a dref/urn box can appear with no preceding tkhd, leaving current_track_ null
+  if(!current_track_)
+  {
+    grklog.error("MJ2: urn box outside of a track");
+    return false;
+  }
   uint8_t version;
   uint32_t flag;
   read_version_and_flag(&headerData, version, flag);

--- a/src/lib/core/fileformat/decompress/FileFormatMJ2Decompress.cpp
+++ b/src/lib/core/fileformat/decompress/FileFormatMJ2Decompress.cpp
@@ -505,11 +505,23 @@ bool FileFormatMJ2Decompress::read_stsd(uint8_t* headerData, uint32_t headerSize
  * Time To Sample box Decompact
  *
  */
-void FileFormatMJ2Decompress::tts_decompact(mj2_tk* tk)
+bool FileFormatMJ2Decompress::tts_decompact(mj2_tk* tk)
 {
+  // Each materialised sample must map to at least one byte of media data, so
+  // the total sample count cannot exceed the file size. This caps a crafted
+  // STTS samples_count_ (raw uint32) that would otherwise drive billions of
+  // push_backs, and prevents num_samples_ (uint32) from wrapping.
+  uint64_t streamLen = stream_ ? stream_->tell() + stream_->numBytesLeft() : 0;
+  uint64_t total = tk->num_samples_;
   for(const auto& tts : tk->tts_)
   {
-    tk->num_samples_ += tts.samples_count_;
+    total += tts.samples_count_;
+    if(total > streamLen)
+    {
+      grklog.error("MJ2 STTS: sample count %llu exceeds %llu-byte stream",
+                   (unsigned long long)total, (unsigned long long)streamLen);
+      return false;
+    }
     for(uint32_t j = 0; j < tts.samples_count_; j++)
     {
       mj2_sample sample;
@@ -517,6 +529,8 @@ void FileFormatMJ2Decompress::tts_decompact(mj2_tk* tk)
       tk->samples_.push_back(sample);
     }
   }
+  tk->num_samples_ = (uint32_t)total;
+  return true;
 }
 
 bool FileFormatMJ2Decompress::read_stts(uint8_t* headerData, uint32_t headerSize)
@@ -535,7 +549,8 @@ bool FileFormatMJ2Decompress::read_stts(uint8_t* headerData, uint32_t headerSize
     tk->tts_.push_back(tts);
   }
 
-  tts_decompact(tk);
+  if(!tts_decompact(tk))
+    return false;
 
   return true;
 }

--- a/src/lib/core/fileformat/decompress/FileFormatMJ2Decompress.cpp
+++ b/src/lib/core/fileformat/decompress/FileFormatMJ2Decompress.cpp
@@ -718,11 +718,24 @@ bool FileFormatMJ2Decompress::readHeader(grk_header_info* header_info)
     return false;
   if(current_track_)
   {
+    // capture the total input size before seeking: numBytesLeft() is not
+    // reliable after seek(0) on the file buffer.
+    streamLength_ = stream_->tell() + stream_->numBytesLeft();
     // seek to beginning of file to get base pointer for absolute STCO offsets
     stream_->seek(0);
     auto basePtr = stream_->currPtr();
     for(const auto& sample : current_track_->samples_)
     {
+      // offset_/samples_size_ come straight from the STCO/STSZ tables and are
+      // used as raw offsets into the file buffer; reject samples that fall
+      // outside it (also covers the 4-byte box-length probe below).
+      if((uint64_t)sample.offset_ + sample.samples_size_ > streamLength_ ||
+         (uint64_t)sample.offset_ + sizeof(uint32_t) > streamLength_)
+      {
+        grklog.error("MJ2: sample at offset %u (size %u) lies outside the %llu-byte stream",
+                     sample.offset_, sample.samples_size_, (unsigned long long)streamLength_);
+        return false;
+      }
       auto ptr = basePtr + sample.offset_;
       // cross-check sample size with box length
       // as long as box is not XL
@@ -761,6 +774,17 @@ bool FileFormatMJ2Decompress::decompressSampleInternal(uint32_t sampleIndex)
   // get base pointer for absolute file offsets
   stream_->seek(0);
   auto basePtr = stream_->currPtr();
+
+  // bound the sample against the file buffer before using offset_ as a pointer
+  // (streamLength_ was captured in readHeader before any seek)
+  if((uint64_t)sample.offset_ + sample.samples_size_ > streamLength_ ||
+     (uint64_t)sample.offset_ + sizeof(uint32_t) > streamLength_)
+  {
+    grklog.error("MJ2: sample %u at offset %u (size %u) lies outside the %llu-byte stream",
+                 sampleIndex, sample.offset_, sample.samples_size_,
+                 (unsigned long long)streamLength_);
+    return false;
+  }
 
   auto samplePtr = basePtr + sample.offset_;
 

--- a/src/lib/core/fileformat/decompress/FileFormatMJ2Decompress.h
+++ b/src/lib/core/fileformat/decompress/FileFormatMJ2Decompress.h
@@ -77,7 +77,7 @@ private:
   bool read_url(uint8_t* headerData, uint32_t headerSize);
   bool read_urn(uint8_t* headerData, uint32_t headerSize);
 
-  void tts_decompact(mj2_tk* tk);
+  bool tts_decompact(mj2_tk* tk);
   void stsc_decompact(mj2_tk* tk);
   void stco_decompact(mj2_tk* tk);
 

--- a/src/lib/core/fileformat/decompress/FileFormatMJ2Decompress.h
+++ b/src/lib/core/fileformat/decompress/FileFormatMJ2Decompress.h
@@ -84,6 +84,10 @@ private:
   grk_decompress_parameters decompressParams_;
   bool decompressParamsSet_;
   std::vector<GrkImage*> decompressedImages_;
+  // total input size, captured during readHeader before any seek (numBytesLeft
+  // is not reliable after seek(0) on the file buffer); used to bound raw
+  // STCO/STSZ sample offsets.
+  uint64_t streamLength_ = 0;
 
   struct SampleCodeStream
   {

--- a/src/lib/core/point_transform/mct.h
+++ b/src/lib/core/point_transform/mct.h
@@ -49,6 +49,13 @@ class Mct
 public:
   Mct(Tile* tile, GrkImage* image, TileCodingParams* tcp);
 
+  /** Re-point the non-owning tile reference (the owning TileProcessor may free
+   *  and recreate its Tile across a re-decompress / cache eviction). */
+  void setTile(Tile* tile)
+  {
+    tile_ = tile;
+  }
+
   /**
    Apply a reversible multi-component transform to an image
    */

--- a/src/lib/core/t1/part15/CoderOJPH.cpp
+++ b/src/lib/core/t1/part15/CoderOJPH.cpp
@@ -27,7 +27,10 @@
 #include <cstdlib>
 #include <cstring>
 
-const uint8_t grk_cblk_dec_compressed_data_pad_ht = 8;
+// 16 bytes: the SIMD HT MagSgn forward reader (frwd_read) issues 16-byte vector
+// loads that may run up to 16 bytes past the end of the code-block data, so the
+// trailing pad must be at least that wide.
+const uint8_t grk_cblk_dec_compressed_data_pad_ht = 16;
 
 // Function pointer types for SIMD-dispatched block coding
 using decode_cb_t = bool (*)(grk::t1::ojph::ui8*, grk::t1::ojph::ui32*, grk::t1::ojph::ui32,

--- a/src/lib/core/tile_processor/TileProcessor.cpp
+++ b/src/lib/core/tile_processor/TileProcessor.cpp
@@ -286,6 +286,10 @@ bool TileProcessor::reinitForReDecompress()
 
   // Recreate tile structure
   tile_ = new Tile(headerImage_->numcomps);
+  // mct_ holds a non-owning Tile*; re-point it at the new tile so the inverse
+  // MCT pass does not dereference the previously freed Tile.
+  if(mct_)
+    mct_->setTile(tile_);
   initialized_ = false;
   scheduledForDecompression_ = false;
 
@@ -929,6 +933,9 @@ void TileProcessor::release(uint32_t strategy)
   // delete tile components
   delete tile_;
   tile_ = nullptr;
+  // drop mct_'s dangling reference to the freed tile
+  if(mct_)
+    mct_->setTile(nullptr);
 
   // delete image in absence of tile cache strategy
   if(strategy == GRK_TILE_CACHE_NONE)
@@ -958,6 +965,9 @@ void TileProcessor::releaseForSwath()
 
   delete tile_;
   tile_ = nullptr;
+  // drop mct_'s dangling reference to the freed tile
+  if(mct_)
+    mct_->setTile(nullptr);
 }
 void TileProcessor::release(void)
 {

--- a/src/lib/core/tile_processor/TileProcessor.cpp
+++ b/src/lib/core/tile_processor/TileProcessor.cpp
@@ -1450,8 +1450,12 @@ void TileProcessor::scheduleAndRunDecompress(CoderPool* coderPool, Rect32 unredu
           scratchImg->decompress_height = h;
           scratchImg->decompress_prec = prec;
           scratchImg->decompress_num_comps = nc;
-          // packed_row_bytes and rows_per_strip must match what the format writer header used
-          scratchImg->packed_row_bytes = ((uint64_t)w * nc * prec + 7U) / 8U;
+          // packed_row_bytes and rows_per_strip must match what the format writer header used.
+          // The PNM streaming packer emits whole 8- or 16-bit samples, so for PXM the row size
+          // must use the rounded byte width, not the raw (bit-packed) precision; otherwise a
+          // precision not in {8,16} under-sizes the strip buffer and the packer overflows it.
+          uint8_t packPrec = (scratchImg->decompress_fmt == GRK_FMT_PXM) ? (prec > 8 ? 16 : 8) : prec;
+          scratchImg->packed_row_bytes = ((uint64_t)w * nc * packPrec + 7U) / 8U;
           scratchImg->rows_per_strip = singleTileRowsPerStrip;
           if(scratchImg->rows_per_strip > h)
             scratchImg->rows_per_strip = h;

--- a/src/lib/core/wavelet/WaveletPoolData.cpp
+++ b/src/lib/core/wavelet/WaveletPoolData.cpp
@@ -19,6 +19,7 @@
 #include "TFSingleton.h"
 #include "simd.h"
 #include "WaveletCommon.h"
+#include "Logger.h"
 
 namespace grk
 {
@@ -38,6 +39,12 @@ bool WaveletPoolData::alloc(size_t maxDim)
 
     size_t buffer_size = maxDim;
     auto multiplier = std::max(sizeof(int32_t) * get_PLL_COLS_53(), sizeof(vec4f));
+    // overflow guard (the sibling dwt_scratch::alloc already has one)
+    if(multiplier && maxDim > SIZE_MAX / multiplier)
+    {
+      grklog.error("WaveletPoolData: scratch size overflow for dimension %zu", maxDim);
+      return false;
+    }
     buffer_size *= multiplier;
     for(size_t i = 0; i < num_threads; ++i)
     {

--- a/src/lib/core/wavelet/WaveletReverse.cpp
+++ b/src/lib/core/wavelet/WaveletReverse.cpp
@@ -2087,6 +2087,10 @@ bool WaveletReverse::tile_16_53(void)
 
 bool WaveletReverse::decompress(void)
 {
+  // The pool allocation may legitimately fail (e.g. a degenerate/oversized
+  // tile dimension whose scratch is never actually used); tolerate that as
+  // before. The overflow guard in alloc() prevents the size computation from
+  // wrapping and under-allocating.
   if(poolData_)
     poolData_->alloc(maxDim_);
 


### PR DESCRIPTION
Fixes the 14 issues Ariel Koren (Anvil) reported privately in GHSA-57w8-h6pj-xx45. One commit per finding; each commit body carries the GROK id, the CWE, and a `Reported-by:` trailer so the mapping back to the advisory is self-contained.

These touch the image-format readers (BMP/JPEG/TIFF), the MJ2 box + sample-table parser, the JP2 asoc parser, the tile-processor MCT lifecycle, the streaming strip composite, the inverse-DWT scratch pool, and the HTJ2K MagSgn SIMD path. None are in the core J2K/T1/T2/wavelet/MQ math.

Highs:
- GROK-0001 (CWE-787) BMP reader — validate biSize before it sizes the header read into the stack buffer
- GROK-0004 (CWE-787) JPEG reader — reject 4-component (CMYK/YCCK) JPEGs before the [3]-sized arrays overflow
- GROK-0007 (CWE-125) MJ2 sample table — bound STCO/STSZ offset+size against the file before using them as pointers
- GROK-0006 (CWE-416) tile-processor MCT — keep the Mct tile pointer in sync on release/re-decompress (UAF)
- GROK-0010 (CWE-787) strip composite — size the strip buffer for the tallest tile-row, not the first

Mediums:
- GROK-0002 (CWE-125) BMP RLE8/RLE4 — bound the input pointer to biSizeImage
- GROK-0005 (CWE-125) TIFF reader — require numcomps == SamplesPerPixel for contiguous data
- GROK-0014 (CWE-770) inverse-DWT scratch — add the overflow guard the sibling already had
- GROK-0011 (CWE-674) JP2 asoc — cap superbox recursion depth

Lows:
- GROK-0009 (CWE-770) MJ2 STTS — cap sample expansion by file size
- GROK-0013 (CWE-476) MJ2 read_url/read_urn — null-check the track
- GROK-0003 (CWE-125) MJ2 read_url/read_urn — guard the headerSize underflow
- GROK-0008 (CWE-787) PNM strip output — size packed_row_bytes to the packer's byte width
- GROK-0012 (CWE-125) HTJ2K — widen code-block padding to 16 bytes for the SIMD MagSgn load

Builds clean and the full test suite passes locally. Headed for 20.3.6.